### PR TITLE
Update AWS Lambda layer Docker image name

### DIFF
--- a/aws-lambda-layer/Rakefile
+++ b/aws-lambda-layer/Rakefile
@@ -8,7 +8,7 @@ DEFAULT_FREETDS_VERSION = '1.1.6'
 desc 'Build FreeTDS AWS Lambda Layer'
 task :build, [:freetds_version] do |_t, args|
   version = args[:freetds_version] || ENV['FREETDS_VERSION'] || DEFAULT_FREETDS_VERSION
-  image_name = "veracross/freetds:#{version}"
+  image_name = "veracross/freetds:aws-lambda-layer-#{version}"
 
   FileUtils.rm_r BUILD_DIR, force: true
   FileUtils.mkdir_p BUILD_DIR


### PR DESCRIPTION
If the docker image that is used to create the AWS Lambda layer is being pushed to Docker Hub (which it is), then we should give this image a more appropriate name and not one that is similar to FreeTDS Docker images that are not for AWS Lambda layer creation and differ in their base image.